### PR TITLE
Fix overflow of project cards' details on some mobile devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "photonic",
-    "version": "1.0.4-3",
+    "version": "1.0.4-4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "photonic",
-            "version": "1.0.4-3",
+            "version": "1.0.4-4",
             "dependencies": {
                 "@astrojs/preact": "^4.0.5",
                 "@astrojs/sitemap": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "photonic",
     "type": "module",
-    "version": "1.0.4-3",
+    "version": "1.0.4-4",
     "scripts": {
         "dev": "astro dev --host",
         "build": "/bin/sh -c '/bin/bash ./scripts/build.sh'",

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -64,7 +64,7 @@ export default class ProjectFilters extends Component<Props, State> {
         );
 
         return (
-            <div class="group h-64 w-full motion-safe:perspective-distant lg:h-96 lg:max-w-96">
+            <div class="group h-80 w-full motion-safe:perspective-distant lg:h-96 lg:max-w-96">
                 <div
                     id={`project-${props.id}`}
                     class="relative mx-auto my-0 h-full w-full cursor-pointer rounded-lg bg-gradient-to-tr from-gray-900 via-slate-700 via-75% to-gray-800 p-3 text-center transition-transform duration-500 *:absolute *:top-0 *:right-0 *:bottom-0 *:left-0 *:flex *:flex-col *:items-center *:justify-center *:p-4 motion-safe:transform-3d motion-safe:*:rotate-x-0 motion-safe:*:backface-hidden motion-reduce:*:transition-opacity motion-reduce:*:duration-300 md:motion-safe:group-hover:rotate-y-180 *:lg:p-8"


### PR DESCRIPTION
# Pull Request

## Description

Fixes an issue with the project cards' details overrunning on some mobile devices.

![Screenshot_20250303-112203](https://github.com/user-attachments/assets/013e4d80-3030-4db8-9736-1235b0e0ebf7)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
