### PR TITLE
Add licensing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "photonic",
-    "version": "1.1.7",
+    "version": "1.1.8-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "photonic",
-            "version": "1.1.7",
+            "version": "1.1.8-0",
             "dependencies": {
                 "@astrojs/partytown": "^2.1.4",
                 "@astrojs/preact": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "photonic",
     "type": "module",
-    "version": "1.1.7",
+    "version": "1.1.8-0",
     "scripts": {
         "dev": "astro dev --host",
         "build": "astro build",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -34,11 +34,14 @@ const year = new Date().getFullYear().toString();
         <span class="block text-sm">
             Copyright &copy; {year} PhotonicGluon
         </span>
-        <span class="block text-xs text-gray-400 print:hidden">
-            Photonic's source code is available on <a href="https://github.com/PhotonicGluon/Photonic">GitHub</a>.
-        </span>
-        <span class="block text-2xs text-gray-400/90 print:text-xs print:text-gray-700">
+        <span class="block text-xs text-gray-400/90 print:text-xs print:text-gray-700">
             Version <Version />
+        </span>
+        <span class="block text-xs print:hidden">
+            <div class="inline-flex gap-8">
+                <a href="https://github.com/PhotonicGluon/Photonic">Source Code</a>
+                <a href="/credits">Credits</a>
+            </div>
         </span>
         <span class="hidden text-2xs text-gray-700 print:block">
             Printed on <span class="font-mono" id="print-timestamp">TIMESTAMP</span>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -41,6 +41,7 @@ const year = new Date().getFullYear().toString();
             <div class="inline-flex gap-8">
                 <a href="https://github.com/PhotonicGluon/Photonic">Source Code</a>
                 <a href="/credits">Credits</a>
+                <a href="/licensing">Licensing</a>
             </div>
         </span>
         <span class="hidden text-2xs text-gray-700 print:block">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -196,14 +196,6 @@ import linkedinLogo from "@images/icons/LI-In-Bug.svg";
         </div>
         <p>I will do my best to respond back. 😊</p>
     </section>
-
-    {/* Credits */}
-    <section>
-        <h2>Credits</h2>
-        <p>
-            <a href="/credits">Click here</a> to see the resources used to make the Photonic website.
-        </p>
-    </section>
 </MainLayout>
 
 <style>

--- a/src/pages/licensing.astro
+++ b/src/pages/licensing.astro
@@ -1,0 +1,55 @@
+---
+import { readFileSync } from "fs";
+
+import SEO from "@components/top/SEO.astro";
+
+import MainLayout from "@layouts/MainLayout.astro";
+
+// Read the `LICENSE` file
+const license = readFileSync("LICENSE", "utf-8").trimEnd();
+---
+
+<MainLayout
+    class="motion-safe:delay-200 motion-safe:duration-300 motion-safe:animate-in motion-safe:fade-in motion-safe:fill-mode-backwards motion-safe:slide-in-from-top-4"
+    title="Licensing"
+>
+    {/* SEO */}
+    <Fragment slot="head-seo">
+        <SEO
+            title="Licensing"
+            description="Licensing information for Photonic's content."
+            openGraph={{
+                title: "Licensing",
+                description: "Licensing information for Photonic's content.",
+                image: {
+                    url: "https://raw.githubusercontent.com/PhotonicGluon/Photonic/4c2ae66/public/favicon.png",
+                    alt: "Photonic Logo",
+                    type: "image/png",
+                    width: 500,
+                    height: 500,
+                },
+            }}
+        />
+    </Fragment>
+
+    {/* Source code */}
+    <section>
+        <h2>Source Code</h2>
+        <p>
+            The source code for Photonic is licensed under the <bold>MIT License</bold>, which is reproduced below.
+        </p>
+        <pre><code>{license}</code></pre>
+    </section>
+</MainLayout>
+
+<style>
+    @import "@styles/global.css";
+
+    h2 {
+        @apply text-3xl font-bold;
+    }
+
+    pre {
+        @apply my-2 w-min overflow-auto rounded-lg !bg-gray-800 p-6 text-sm print:border print:border-gray-600 print:!bg-transparent print:whitespace-pre-wrap;
+    }
+</style>

--- a/src/pages/licensing.astro
+++ b/src/pages/licensing.astro
@@ -36,7 +36,8 @@ const license = readFileSync("LICENSE", "utf-8").trimEnd();
     <section>
         <h2>Source Code</h2>
         <p>
-            The source code for Photonic is licensed under the <bold>MIT License</bold>, which is reproduced below.
+            The source code for Photonic is licensed under the <span class="font-bold">MIT License</span>, which is
+            reproduced below.
         </p>
         <pre><code>{license}</code></pre>
     </section>

--- a/src/pages/licensing.astro
+++ b/src/pages/licensing.astro
@@ -50,6 +50,6 @@ const license = readFileSync("LICENSE", "utf-8").trimEnd();
     }
 
     pre {
-        @apply my-2 w-min overflow-auto rounded-lg !bg-gray-800 p-6 text-sm print:border print:border-gray-600 print:!bg-transparent print:whitespace-pre-wrap;
+        @apply my-2 w-min max-w-full overflow-auto rounded-lg !bg-gray-800 p-6 text-sm print:w-full print:border print:border-gray-600 print:!bg-transparent print:text-xs print:whitespace-pre-wrap;
     }
 </style>


### PR DESCRIPTION
## Description

Create a page which shows the licensing information of content on Photonic.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
